### PR TITLE
Macos fix

### DIFF
--- a/installRemote.sh
+++ b/installRemote.sh
@@ -1,6 +1,6 @@
 version=$(node -p "require('./package.json').version")
 
-. /etc/os-release
+. /etc/os-release || true
 if [ `which apk` ]; then
   os=alpine
 elif [ "$(uname)" = "Linux" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "repository": "https://github.com/markwylde/node-ejdb-lite.git",
   "author": "Anton Adamansky <adamansky@gmail.com>",
   "description": "Blazing fast (installs in seconds) and lightweight EJDB2 bindings for NodeJS",


### PR DESCRIPTION
This should allow installs to work on macos, by ignoring the linux os check and then building by source.