### PR TITLE
v2.73.19 - 2022-11-18 - Pull in latest changes from SoftMotions

### DIFF
--- a/installSource.sh
+++ b/installSource.sh
@@ -1,4 +1,4 @@
-SOFTMOTIONS_BRANCH=bc370d1aab86d5e2b8b15cbd7f804d3bbc6db185
+SOFTMOTIONS_BRANCH=d46f8515978e80d0df900ceab86da42d0968d860
 rm -rf ejdb
 git clone --depth=1 --recursive https://github.com/Softmotions/ejdb.git
 cd ejdb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.18",
+  "version": "2.73.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-ejdb-lite",
-      "version": "2.73.18",
+      "version": "2.73.19",
       "cpu": [
         "x64",
         "x32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.18",
+  "version": "2.73.19",
   "repository": "https://github.com/markwylde/node-ejdb-lite.git",
   "author": "Anton Adamansky <adamansky@gmail.com>",
   "description": "Blazing fast (installs in seconds) and lightweight EJDB2 bindings for NodeJS",


### PR DESCRIPTION
Pull in the latest changes from softmotions
```
softmotions/ejdb head:
   d46f8515978e80d0df900ceab86da42d0968d860

markwylde/node-ejdb-lite using:
   bc370d1aab86d5e2b8b15cbd7f804d3bbc6db185

Differences since current release:
   - Changelog
   - extra/iowow
   - extra/iwnet
   - src/ejdb2.h
   - src/jbi/jbi_sorter_consumer.c
   - src/tests/CMakeLists.txt
   - src/tests/ejdb_test5.c
   - src/tests/yarn.lock
```