### PR TITLE
v2.73.20 - 2022-11-29 - Pull in latest changes from SoftMotions

### DIFF
--- a/installSource.sh
+++ b/installSource.sh
@@ -1,4 +1,4 @@
-SOFTMOTIONS_BRANCH=d46f8515978e80d0df900ceab86da42d0968d860
+SOFTMOTIONS_BRANCH=aa753704f45b13101cb90894e06de3aab98224c2
 rm -rf ejdb
 git clone --depth=1 --recursive https://github.com/Softmotions/ejdb.git
 cd ejdb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.19",
+  "version": "2.73.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-ejdb-lite",
-      "version": "2.73.19",
+      "version": "2.73.20",
       "cpu": [
         "x64",
         "x32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.19",
+  "version": "2.73.20",
   "repository": "https://github.com/markwylde/node-ejdb-lite.git",
   "author": "Anton Adamansky <adamansky@gmail.com>",
   "description": "Blazing fast (installs in seconds) and lightweight EJDB2 bindings for NodeJS",


### PR DESCRIPTION
Pull in the latest changes from softmotions
```
softmotions/ejdb head:
   aa753704f45b13101cb90894e06de3aab98224c2

markwylde/node-ejdb-lite using:
   d46f8515978e80d0df900ceab86da42d0968d860

Differences since current release:
   - CMakeLists.txt
   - docker/testbed/llvm.sh
   - installer/core/CMakeLists.txt
   - installer/jni/CMakeLists.txt
   - src/bindings/ejdb2_node/index.js
   - src/bindings/ejdb2_node/install.js
   - src/bindings/ejdb2_node/version.txt
```