### PR TITLE
v2.73.22 - 2023-01-09 - Pull in latest changes from SoftMotions

### DIFF
--- a/installSource.sh
+++ b/installSource.sh
@@ -1,4 +1,4 @@
-SOFTMOTIONS_BRANCH=79b51947d1c30c2bdac65715bc2939db1443081b
+SOFTMOTIONS_BRANCH=a3e0cf2fd90ff7ba0a53bbd31d967a97aa462e4f
 rm -rf ejdb
 git clone --depth=1 --recursive https://github.com/Softmotions/ejdb.git
 cd ejdb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.21",
+  "version": "2.73.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-ejdb-lite",
-      "version": "2.73.21",
+      "version": "2.73.22",
       "cpu": [
         "x64",
         "x32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.21",
+  "version": "2.73.22",
   "repository": "https://github.com/markwylde/node-ejdb-lite.git",
   "author": "Anton Adamansky <adamansky@gmail.com>",
   "description": "Blazing fast (installs in seconds) and lightweight EJDB2 bindings for NodeJS",


### PR DESCRIPTION
Pull in the latest changes from softmotions
```
softmotions/ejdb head:
   a3e0cf2fd90ff7ba0a53bbd31d967a97aa462e4f

markwylde/node-ejdb-lite using:
   79b51947d1c30c2bdac65715bc2939db1443081b

Differences since current release:
   - Changelog
   - WINDOWS.md
   - cmake/Modules/UploadPPA.cmake
   - extra/iowow
   - src/bindings/ejdb2_node/yarn.lock
   - src/jql/jql.c
   - src/tests/ejdb_test5.c
   - src/tests/yarn.lock
```