### PR TITLE
v2.73.25 - 2023-03-20 - Pull in latest changes from SoftMotions

### DIFF
--- a/installSource.sh
+++ b/installSource.sh
@@ -1,4 +1,4 @@
-SOFTMOTIONS_BRANCH=bd667665400d9e3e57c4b7013ce6e6c0c4556ee3
+SOFTMOTIONS_BRANCH=37237a1d93857983be4972e26b0f28c9a1e9ec3b
 rm -rf ejdb
 git clone --depth=1 --recursive https://github.com/Softmotions/ejdb.git
 cd ejdb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.24",
+  "version": "2.73.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-ejdb-lite",
-      "version": "2.73.24",
+      "version": "2.73.25",
       "cpu": [
         "x64",
         "x32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ejdb-lite",
-  "version": "2.73.24",
+  "version": "2.73.25",
   "repository": "https://github.com/markwylde/node-ejdb-lite.git",
   "author": "Anton Adamansky <adamansky@gmail.com>",
   "description": "Blazing fast (installs in seconds) and lightweight EJDB2 bindings for NodeJS",


### PR DESCRIPTION
Pull in the latest changes from softmotions
```
softmotions/ejdb head:
   37237a1d93857983be4972e26b0f28c9a1e9ec3b

markwylde/node-ejdb-lite using:
   bd667665400d9e3e57c4b7013ce6e6c0c4556ee3

Differences since current release:
   - .gdbinit
   - BASE.md
   - Changelog
   - README.md
   - src/jql/jql.c
   - src/jql/jqp.c
   - src/jql/jqp.leg
   - src/jql/tests/jql_test1.c
```